### PR TITLE
Make Glsl immutable

### DIFF
--- a/src/glsl/Glsl.ts
+++ b/src/glsl/Glsl.ts
@@ -1,5 +1,6 @@
-import { ProcessedTransformDefinition } from './transformDefinitions';
 import { Output } from '../Output';
+import ImmutableList from './ImmutableList';
+import { ProcessedTransformDefinition } from './transformDefinitions';
 
 export interface TransformApplication {
   transform: ProcessedTransformDefinition;
@@ -7,13 +8,14 @@ export interface TransformApplication {
 }
 
 export class Glsl {
-  transforms: TransformApplication[];
+  transforms: ImmutableList<TransformApplication>;
 
-  constructor(transformApplication: TransformApplication) {
-    this.transforms = [transformApplication];
+  constructor(transforms: ImmutableList<TransformApplication>) {
+    this.transforms = transforms;
   }
 
   out(output: Output) {
-    output.render(this.transforms);
+    output.render(this.transforms.toArray());
   }
 }
+

--- a/src/glsl/ImmutableList.ts
+++ b/src/glsl/ImmutableList.ts
@@ -1,0 +1,30 @@
+/**
+ * Bare bones append only immutable list.
+ */
+export default class ImmutableList<T> {
+  readonly parent: ImmutableList<T> | undefined;
+
+  readonly element: T;
+
+  constructor(element: T, parent?: ImmutableList<T>) {
+    this.parent = parent;
+    this.element = element;
+  }
+
+  append(element: T): ImmutableList<T> {
+    return new ImmutableList(element, this);
+  }
+
+  toArray(): T[] {
+    if (!this.parent) {
+      return [this.element];
+    }
+    const elements = this.parent.toArray();
+    elements.push(this.element);
+    return elements;
+  }
+
+  forEach(callbackfn: (value: T, index: number, array: T[]) => void) {
+    this.toArray().forEach(callbackfn);
+  }
+}

--- a/src/glsl/createGenerators.ts
+++ b/src/glsl/createGenerators.ts
@@ -4,6 +4,7 @@ import {
   TransformDefinitionType,
 } from './transformDefinitions.js';
 import { Glsl } from './Glsl';
+import ImmutableList from './ImmutableList.js';
 
 type GeneratorMap = Record<string, (...args: unknown[]) => Glsl>;
 
@@ -21,10 +22,10 @@ export function createGenerators({
     const processed = processGlsl(transform);
 
     generatorMap[processed.name] = (...args: unknown[]) =>
-      new sourceClass({
+      new sourceClass(new ImmutableList({
         transform: processed,
         userArgs: args,
-      });
+      }));
   }
 
   for (const transform of modifierTransforms) {
@@ -44,12 +45,12 @@ export function createTransformOnPrototype(
     this: Glsl,
     ...args: unknown[]
   ): Glsl {
-    this.transforms.push({
+    const transform = {
       transform: processedTransformDefinition,
       userArgs: args,
-    });
+    };
 
-    return this;
+    return new cls(this.transforms.append(transform));
   }
 
   cls.prototype[processedTransformDefinition.name] =


### PR DESCRIPTION
Before, the Glsl transforms list was mutated by every chained transform
call. Now, it's immutable, and each chained call will return a new
instance. This is implemented with a simple and efficient ImmutableList.

This is nice to have so you can share and extend the same transforms
between multiple outputs! And it protects noobs like me from weird state
bugs.