### PR TITLE
Add ts-ignore for some existing errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
   },
   "rules": {
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { "argsIgnorePattern": "^_" }

--- a/src/compiler/generateGlsl.ts
+++ b/src/compiler/generateGlsl.ts
@@ -59,8 +59,10 @@ export function generateGlsl(
     } else if (transformApplication.transform.type === 'combine') {
       // combining two generated shader strings (i.e. for blend, mult, add funtions)
       f1 =
+        // @ts-ignore
         typedArgs[0].value && typedArgs[0].value.transforms
           ? (uv: string) =>
+              // @ts-ignore
               `${generateGlsl(typedArgs[0].value.transforms, shaderParams)(uv)}`
           : typedArgs[0].isUniform
           ? () => typedArgs[0].name
@@ -75,8 +77,10 @@ export function generateGlsl(
     } else if (transformApplication.transform.type === 'combineCoord') {
       // combining two generated shader strings (i.e. for modulate functions)
       f1 =
+        // @ts-ignore
         typedArgs[0].value && typedArgs[0].value.transforms
           ? (uv: string) =>
+              // @ts-ignore
               `${generateGlsl(typedArgs[0].value.transforms, shaderParams)(uv)}`
           : typedArgs[0].isUniform
           ? () => typedArgs[0].name
@@ -105,8 +109,10 @@ function shaderString(
     .map((input) => {
       if (input.isUniform) {
         return input.name;
+      // @ts-ignore
       } else if (input.value && input.value.transforms) {
         // this by definition needs to be a generator, hence we start with 'st' as the initial value for generating the glsl fragment
+        // @ts-ignore
         return `${generateGlsl(input.value.transforms, shaderParams)('st')}`;
       }
       return input.value;

--- a/src/glsl/createGenerators.ts
+++ b/src/glsl/createGenerators.ts
@@ -66,6 +66,7 @@ export function addTransformChainMethod(
     return new cls(this.transforms.append(transform));
   }
 
+  // @ts-ignore
   cls.prototype[processedTransformDefinition.name] =
     addTransformApplicationToInternalChain;
 }


### PR DESCRIPTION
When downstream users of this package run `tsc`, they see these errors
and have no way to disable them. Since this package is not in active
maintenance, just add ignores for now.

Fixes #6