### PR TITLE
Forward texture params from Source init methods, like hydra-synth

### DIFF
--- a/src/Source.ts
+++ b/src/Source.ts
@@ -1,6 +1,6 @@
 import { Webcam } from './lib/Webcam.js';
 import { Screen } from './lib/Screen.js';
-import { Texture2D, TextureImageData } from 'regl';
+import { Texture2D, Texture2DOptions, TextureImageData } from 'regl';
 import { GlEnvironment, Synth } from './Hydra.js';
 
 export class Source {
@@ -21,28 +21,40 @@ export class Source {
     });
   }
 
-  init = (opts: { src: Source['src']; dynamic: boolean }) => {
-    if (opts.src) {
+  // `params` is forwarded to regl.texture() on every init* method, matching
+  // hydra-synth — e.g. s0.initCam(0, { min: 'linear', mag: 'linear' })
+  // enables smooth texture filtering.
+  init = (
+    opts: { src?: Source['src']; dynamic?: boolean },
+    params?: Texture2DOptions,
+  ) => {
+    if ('src' in opts) {
       this.src = opts.src;
-      this.tex = this.environment.regl.texture(this.src);
+      this.tex = this.environment.regl.texture({
+        data: this.src,
+        ...params,
+      } as Texture2DOptions);
     }
 
-    if (opts.dynamic) {
+    if ('dynamic' in opts && opts.dynamic !== undefined) {
       this.dynamic = opts.dynamic;
     }
   };
 
-  initCam = (index: number) => {
+  initCam = (index: number, params?: Texture2DOptions) => {
     Webcam(index)
       .then((video) => {
         this.src = video;
         this.dynamic = true;
-        this.tex = this.environment.regl.texture(video);
+        this.tex = this.environment.regl.texture({
+          data: video,
+          ...params,
+        } as Texture2DOptions);
       })
       .catch((err) => console.log('could not get camera', err));
   };
 
-  initVideo = (url = '') => {
+  initVideo = (url = '', params?: Texture2DOptions) => {
     const vid = document.createElement('video');
     vid.crossOrigin = 'anonymous';
     vid.autoplay = true;
@@ -52,28 +64,39 @@ export class Source {
     vid.addEventListener('loadeddata', () => {
       this.src = vid;
       vid.play();
-      this.tex = this.environment.regl.texture(this.src);
+      this.tex = this.environment.regl.texture({
+        data: this.src,
+        ...params,
+      } as Texture2DOptions);
       this.dynamic = true;
     });
     vid.src = url;
   };
 
-  initImage = (url = '') => {
+  initImage = (url = '', params?: Texture2DOptions) => {
     const img = document.createElement('img');
     img.crossOrigin = 'anonymous';
     img.src = url;
     img.onload = () => {
       this.src = img;
       this.dynamic = false;
-      this.tex = this.environment.regl.texture(this.src);
+      this.tex = this.environment.regl.texture({
+        data: this.src,
+        ...params,
+      } as Texture2DOptions);
     };
   };
 
-  initScreen = () => {
+  // index is only relevant in atom-hydra + desktop apps; accepted for
+  // signature parity with hydra-synth
+  initScreen = (_index = 0, params?: Texture2DOptions) => {
     Screen()
       .then((video) => {
         this.src = video;
-        this.tex = this.environment.regl.texture(this.src);
+        this.tex = this.environment.regl.texture({
+          data: this.src,
+          ...params,
+        } as Texture2DOptions);
         this.dynamic = true;
       })
       .catch((err) => console.log('could not get screen', err));

--- a/test/equivalence/source.test.ts
+++ b/test/equivalence/source.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Source equivalence: texture creation (including the `params` passthrough
+ * to regl.texture used for filtering options) matches hydra-synth.
+ */
+import { describe, expect, test } from 'vitest';
+
+// @ts-ignore - untyped upstream javascript
+import UpstreamSource from '../../node_modules/hydra-synth/src/hydra-source.js';
+
+import { Source } from '../../src/Source';
+import { GlEnvironment } from '../../src/Hydra';
+
+interface TextureCall {
+  args: unknown[];
+}
+
+function makeStubRegl() {
+  const textureCalls: TextureCall[] = [];
+  return {
+    textureCalls,
+    regl: {
+      texture: (...args: unknown[]) => {
+        textureCalls.push({ args });
+        return { kind: 'texture', args, subimage: () => {}, resize: () => {} };
+      },
+    },
+  };
+}
+
+function makeSources() {
+  const upstreamStub = makeStubRegl();
+  const tsStub = makeStubRegl();
+
+  const upstream = new UpstreamSource({
+    regl: upstreamStub.regl,
+    width: 320,
+    height: 240,
+    pb: null,
+    label: 's0',
+  });
+
+  const ours = new Source({
+    regl: tsStub.regl,
+    width: 320,
+    height: 240,
+  } as unknown as GlEnvironment);
+
+  return { upstream, ours, upstreamStub, tsStub };
+}
+
+describe('Source', () => {
+  test('constructor creates the same initial texture', () => {
+    const { upstreamStub, tsStub } = makeSources();
+    expect(tsStub.textureCalls).toEqual(upstreamStub.textureCalls);
+  });
+
+  test('init() forwards texture params identically to upstream', () => {
+    const { upstream, ours, upstreamStub, tsStub } = makeSources();
+    const media = { width: 4, height: 4 };
+    const params = { min: 'linear', mag: 'linear' };
+
+    upstream.init({ src: media }, params);
+    ours.init({ src: media as any }, params as any);
+
+    expect(tsStub.textureCalls.at(-1)).toEqual(
+      upstreamStub.textureCalls.at(-1),
+    );
+    expect(tsStub.textureCalls.at(-1)!.args[0]).toMatchObject({
+      data: media,
+      min: 'linear',
+      mag: 'linear',
+    });
+  });
+
+  test('init() without params matches upstream', () => {
+    const { upstream, ours, upstreamStub, tsStub } = makeSources();
+    const media = { width: 8, height: 8 };
+
+    upstream.init({ src: media });
+    ours.init({ src: media as any });
+
+    expect(tsStub.textureCalls.at(-1)).toEqual(
+      upstreamStub.textureCalls.at(-1),
+    );
+  });
+
+  test('init() can disable dynamic, like upstream', () => {
+    const { upstream, ours } = makeSources();
+
+    expect(ours.dynamic).toBe(upstream.dynamic);
+
+    upstream.init({ dynamic: false });
+    ours.init({ dynamic: false });
+
+    expect(upstream.dynamic).toBe(false);
+    expect(ours.dynamic).toBe(false);
+  });
+});


### PR DESCRIPTION
Every `Source.init*` method now accepts an optional `params` argument that is spread into `regl.texture()`, matching hydra-synth's signatures (`init(opts, params)`, `initCam(index, params)`, `initVideo(url, params)`, `initImage(url, params)`, `initScreen(index, params)`).

This closes a real visual-parity gap: `params` is how hydra sketches configure texture filtering, e.g. `s0.initCam(0, { min: 'linear', mag: 'linear' })`, which changes how source textures are sampled.

`init()` also now follows upstream's `'key' in opts` semantics, so `init({ dynamic: false })` works (previously the falsy check made it impossible to disable `dynamic` through `init`).

Equivalence tests drive hydra-ts's `Source` and hydra-synth's `HydraSource` against the same stubbed regl and assert identical `regl.texture()` calls, with and without params.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_