### PR TITLE
Add instance-bound generators with a default output

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ const hydra = new Hydra({ regl, width, height, precision: detectPrecision() });
 #### Recreating the hydra-editor global environment
 
 ```ts
-import { Hydra, generators } from 'hydra-ts';
+import { Hydra } from 'hydra-ts';
 
 const hydra = new Hydra(/* ... */);
 
-const { src, osc, gradient, shape, voronoi, noise, solid, prev } = generators;
+const { src, osc, gradient, shape, voronoi, noise, solid, prev } =
+  hydra.generators;
 const { sources, outputs } = hydra;
 
 const [s0, s1, s2, s3] = sources;
@@ -88,9 +89,16 @@ const [o0, o1, o2, o3] = outputs;
 const { hush, loop, render } = hydra;
 
 loop.start();
+
+osc(60).out(); // chains from hydra.generators default to o0, like the editor
 ```
 
-Generators are no longer dependent on the Hydra environment, so you can import them directly from `'hydra-ts'`;
+`hydra.generators` are bound to their instance: `.out()` with no argument
+renders to that instance's first output, matching the editor.
+
+Generators that do not depend on any Hydra environment can also be imported
+directly from `'hydra-ts'` (`import { generators } from 'hydra-ts'`); chains
+built from those require an explicit output: `osc(60).out(o0)`.
 
 Sources and outputs may be named when destructuring from their respective properties on the hydra instance.
 
@@ -204,8 +212,10 @@ compiler.
 
 ## Differences from the original hydra-synth
 
-Presently, you must pass an output instance to `.out(o#)` - it does not infer the "default" output if none is passed.
-PRs to address this are welcome.
+Chains built from the environment-free generators (`import { generators } from 'hydra-ts'`)
+require an explicit output: `.out(o0)`. Chains built from an instance's bound
+generators (`hydra.generators`) default to that instance's first output, like
+the original.
 
 You must also call ArrayUtils.init() once before any instance of hydra is used.
 

--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -10,6 +10,15 @@ import { Output } from './Output.js';
 import { Loop } from './Loop.js';
 import { Source } from './Source.js';
 import { solid } from './glsl/index.js';
+import {
+  createGenerators,
+  createTransformChainClass,
+  Generator,
+} from './glsl/createGenerators.js';
+import {
+  generatorTransforms,
+  modifierTransforms,
+} from './glsl/transformDefinitions.js';
 
 export type Precision = 'lowp' | 'mediump' | 'highp';
 
@@ -70,6 +79,13 @@ export class Hydra {
   readonly synth: Synth;
   readonly outputs: Output[];
   readonly sources: Source[];
+  /**
+   * Generators bound to this instance: chains built from them default to
+   * this Hydra's first output, so `hydra.generators.osc().out()` works like
+   * the hydra editor. The module-level generators exported from 'hydra-ts'
+   * remain environment-free and require an explicit output.
+   */
+  readonly generators: Record<string, Generator>;
   #output: Output;
   #isRenderingAll = false;
   readonly #renderFbo: DrawCommand<DefaultContext>;
@@ -218,6 +234,11 @@ export class Hydra {
     this.#output = outputs[0];
     this.#renderFbo = renderFbo;
     this.#renderAll = renderAll;
+    this.generators = createGenerators(
+      generatorTransforms,
+      createTransformChainClass(modifierTransforms),
+      outputs[0],
+    );
   }
 
   hush = () => {

--- a/src/glsl/Glsl.ts
+++ b/src/glsl/Glsl.ts
@@ -14,13 +14,29 @@ export interface TransformApplication {
 
 export class Glsl {
   transforms: ImmutableList<TransformApplication>;
+  readonly defaultOutput?: Output;
 
-  constructor(transforms: ImmutableList<TransformApplication>) {
+  constructor(
+    transforms: ImmutableList<TransformApplication>,
+    defaultOutput?: Output,
+  ) {
     this.transforms = transforms;
+    this.defaultOutput = defaultOutput;
   }
 
-  out(output: Output) {
-    output.render(this.transforms.toArray());
+  out(output?: Output) {
+    const target = output ?? this.defaultOutput;
+
+    if (target === undefined) {
+      throw new Error(
+        '.out() was called without an output, and this chain has no default ' +
+          'output. Pass an output (e.g. .out(o0)), or build the chain with ' +
+          "a Hydra instance's bound generators (hydra.generators), which " +
+          "default to that instance's first output.",
+      );
+    }
+
+    target.render(this.transforms.toArray());
   }
 
   /**

--- a/src/glsl/createGenerators.ts
+++ b/src/glsl/createGenerators.ts
@@ -5,9 +5,10 @@ import {
   TransformDefinitionType,
 } from './transformDefinitions.js';
 import { Glsl } from './Glsl.js';
+import { Output } from '../Output.js';
 import ImmutableList from './ImmutableList.js';
 
-type Generator = (...args: unknown[]) => Glsl;
+export type Generator = (...args: unknown[]) => Glsl;
 
 export function createTransformChainClass<
   T extends readonly TransformDefinition[],
@@ -26,6 +27,7 @@ export function createTransformChainClass<
 export function createGenerator(
   generatorTransform: TransformDefinition,
   TransformChainClass: typeof Glsl,
+  defaultOutput?: Output,
 ): Generator {
   const processed = processGlsl(generatorTransform);
 
@@ -35,17 +37,23 @@ export function createGenerator(
         transform: processed,
         userArgs: args,
       }),
+      defaultOutput,
     );
 }
 
 export function createGenerators(
   generatorTransforms: readonly TransformDefinition[],
   sourceClass: typeof Glsl,
+  defaultOutput?: Output,
 ): Record<string, Generator> {
   const generatorMap: Record<string, Generator> = {};
 
   for (const transform of generatorTransforms) {
-    generatorMap[transform.name] = createGenerator(transform, sourceClass);
+    generatorMap[transform.name] = createGenerator(
+      transform,
+      sourceClass,
+      defaultOutput,
+    );
   }
 
   return generatorMap;
@@ -64,7 +72,7 @@ export function addTransformChainMethod(
       userArgs: args,
     };
 
-    return new cls(this.transforms.append(transform));
+    return new cls(this.transforms.append(transform), this.defaultOutput);
   }
 
   // @ts-ignore

--- a/test/equivalence/defaultOutput.test.ts
+++ b/test/equivalence/defaultOutput.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Instance-bound generators: hydra.generators chains default to the
+ * instance's first output, matching hydra-synth's defaultOutput behavior —
+ * without any global state. The module-level generators stay
+ * environment-free and require an explicit output.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { Hydra } from '../../src/Hydra';
+import * as moduleGenerators from '../../src/glsl';
+import { osc } from '../../src/glsl';
+import { compileGlsl } from '../../src/compiler/compileWithEnvironment';
+import { Glsl } from '../../src/glsl/Glsl';
+
+function makeStubRegl() {
+  const stub: any = (config: Record<string, unknown>) => {
+    stub.commands.push(config);
+    return () => {};
+  };
+  stub.commands = [] as Array<Record<string, unknown>>;
+  stub.buffer = (data: unknown) => ({ kind: 'buffer', data });
+  stub.texture = (opts: unknown) => ({ kind: 'texture', opts });
+  stub.framebuffer = (opts: unknown) => ({
+    kind: 'framebuffer',
+    opts,
+    resize: () => {},
+  });
+  stub.prop = (name: string) => `prop:${name}`;
+  return stub;
+}
+
+function makeHydra() {
+  const regl = makeStubRegl();
+  const hydra = new Hydra({ regl, width: 320, height: 240 });
+  return { hydra, regl };
+}
+
+describe('hydra.generators', () => {
+  test('exposes the same generator names as the module-level export', () => {
+    const { hydra } = makeHydra();
+    expect(Object.keys(hydra.generators).sort()).toEqual(
+      Object.keys(moduleGenerators).sort(),
+    );
+  });
+
+  test('.out() with no argument renders to the first output', () => {
+    const { hydra } = makeHydra();
+    const before = hydra.outputs[0].draw;
+
+    hydra.generators.osc(10).out();
+
+    expect(hydra.outputs[0].draw).not.toBe(before);
+  });
+
+  test('default output survives chaining through modifiers', () => {
+    const { hydra } = makeHydra();
+    const before = hydra.outputs[0].draw;
+
+    (hydra.generators.osc(10) as any).rotate(0.3).kaleid(4).out();
+
+    expect(hydra.outputs[0].draw).not.toBe(before);
+  });
+
+  test('.out(output) still targets the given output', () => {
+    const { hydra } = makeHydra();
+    const before0 = hydra.outputs[0].draw;
+    const before1 = hydra.outputs[1].draw;
+
+    hydra.generators.osc(10).out(hydra.outputs[1]);
+
+    expect(hydra.outputs[0].draw).toBe(before0);
+    expect(hydra.outputs[1].draw).not.toBe(before1);
+  });
+
+  test('bound chains compile to the same shader as unbound chains', () => {
+    const { hydra } = makeHydra();
+
+    const bound = (hydra.generators.osc(13, 0.2) as any).rotate(0.4) as Glsl;
+    const unbound = (osc(13, 0.2) as any).rotate(0.4) as Glsl;
+
+    expect(compileGlsl(bound.transforms.toArray()).fragColor).toBe(
+      compileGlsl(unbound.transforms.toArray()).fragColor,
+    );
+  });
+});
+
+describe('module-level generators', () => {
+  test('.out() with no argument throws a descriptive error', () => {
+    expect(() => osc(10).out()).toThrow('.out() was called without an output');
+  });
+});


### PR DESCRIPTION
Closes the long-standing README-flagged gap: `.out()` with no argument.

`hydra.generators` exposes the same generator functions as the module-level export, but chains built from them carry a reference to that Hydra instance's first output — so `hydra.generators.osc().out()` works exactly like the hydra editor (and hydra-synth's `defaultOutput`). This is upstream's `GeneratorFactory({ defaultOutput })` architecture minus the global registration: the default is per-instance and referential, never ambient.

- `Glsl` chains carry an optional `defaultOutput`; `.out()` falls back to it, and chain methods propagate it through immutable chain extension.
- Module-level generators remain environment-free; `.out()` without an output there now throws a descriptive error instead of a `TypeError`.
- `createGenerator`/`createGenerators` accept an optional `defaultOutput` for custom transform setups.
- README's "Recreating the hydra-editor global environment" section now shows the bound-generator setup, and the "Differences" caveat is updated.

Tests cover: bound `.out()` renders to the first output, binding survives modifier chaining, explicit `.out(o1)` still wins, bound and unbound chains compile identical shader code, and the module-level error message.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_