### PR TITLE
Add a props option for injecting per-frame values into draws

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ const hydra = new Hydra({
 osc(({ mouse }) => mouse.x / 100).out(o0);
 ```
 
+Injected values cannot override the synth's own per-frame values (`time`,
+`bpm`, `resolution`, ...), and a throwing `props` callback is logged and
+skipped for that frame rather than aborting it.
+
 #### Adding custom generator or modifier hydra functions (e.g. `setFunction`)
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -104,6 +104,21 @@ hydra.synth.afterUpdate = (dt) => {};
 `hush()` resets both, clears all sources, and renders transparent black to
 every output, matching upstream behavior.
 
+#### Supplying extra per-frame values (e.g. `mouse`)
+
+Dynamic (function) arguments receive `{ time, bpm, resolution, ... }` each
+frame. hydra-synth additionally passes a global `mouse`; hydra-ts instead
+lets you inject any values you like:
+
+```ts
+const hydra = new Hydra({
+  // ...
+  props: () => ({ mouse: { x: pointerX, y: pointerY } }),
+});
+
+osc(({ mouse }) => mouse.x / 100).out(o0);
+```
+
 #### Adding custom generator or modifier hydra functions (e.g. `setFunction`)
 
 ```ts

--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -61,6 +61,13 @@ interface HydraRendererOptions {
   numOutputs?: number;
   numSources?: number;
   precision?: Precision;
+  /**
+   * Extra values merged into the props that dynamic (function) arguments
+   * receive each frame, alongside time/bpm/resolution. hydra-synth passes
+   * `mouse` this way; hydra-ts leaves such inputs to the caller:
+   * `props: () => ({ mouse })` recreates upstream's behavior.
+   */
+  props?: () => Record<string, unknown>;
   regl: Regl;
   width: number;
 }
@@ -74,6 +81,7 @@ export class Hydra {
   #isRenderingAll = false;
   readonly #renderFbo: DrawCommand<DefaultContext>;
   readonly #renderAll?: DrawCommand<DefaultContext>;
+  readonly #props?: () => Record<string, unknown>;
   #timeSinceLastUpdate = 0;
 
   constructor({
@@ -81,6 +89,7 @@ export class Hydra {
     numOutputs = 4,
     numSources = 4,
     precision = 'mediump',
+    props,
     regl,
     width,
   }: HydraRendererOptions) {
@@ -218,6 +227,7 @@ export class Hydra {
     this.#output = outputs[0];
     this.#renderFbo = renderFbo;
     this.#renderAll = renderAll;
+    this.#props = props;
   }
 
   hush = () => {
@@ -269,12 +279,16 @@ export class Hydra {
         }
       }
 
+      const drawProps = this.#props
+        ? { ...this.synth, ...this.#props() }
+        : this.synth;
+
       this.sources.forEach((source) => {
-        source.draw(this.synth);
+        source.draw(drawProps);
       });
 
       this.outputs.forEach((output) => {
-        output.draw(this.synth);
+        output.draw(drawProps);
       });
 
       if (this.#isRenderingAll && this.#renderAll) {

--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -66,6 +66,9 @@ interface HydraRendererOptions {
    * receive each frame, alongside time/bpm/resolution. hydra-synth passes
    * `mouse` this way; hydra-ts leaves such inputs to the caller:
    * `props: () => ({ mouse })` recreates upstream's behavior.
+   *
+   * Injected values never replace the synth's own per-frame values, and a
+   * throwing callback is logged and skipped for that frame.
    */
   props?: () => Record<string, unknown>;
   regl: Regl;
@@ -279,9 +282,17 @@ export class Hydra {
         }
       }
 
-      const drawProps = this.#props
-        ? { ...this.synth, ...this.#props() }
-        : this.synth;
+      // synth fields are spread last so injected values can never replace
+      // the core per-frame values (time, bpm, resolution, ...); a throwing
+      // props callback is logged and skipped rather than aborting the frame
+      let drawProps: Synth = this.synth;
+      if (this.#props) {
+        try {
+          drawProps = { ...this.#props(), ...this.synth };
+        } catch (e) {
+          console.log(e);
+        }
+      }
 
       this.sources.forEach((source) => {
         source.draw(drawProps);

--- a/test/equivalence/props.test.ts
+++ b/test/equivalence/props.test.ts
@@ -73,4 +73,44 @@ describe('Hydra props option', () => {
 
     expect(sourceDraw.mock.calls[0][0]).toBe(hydra.synth);
   });
+
+  test('injected values cannot override synth per-frame values', () => {
+    const hydra = new Hydra({
+      regl: makeStubRegl(),
+      width: 320,
+      height: 240,
+      props: () => ({ time: 99999, resolution: [1, 1], mouse: { x: 3 } }),
+    });
+
+    const sourceDraw = vi.fn();
+    hydra.sources[0].draw = sourceDraw;
+
+    hydra.tick(16);
+
+    const props = sourceDraw.mock.calls[0][0];
+    expect(props.time).toBe(hydra.synth.time);
+    expect(props.resolution).toEqual([320, 240]);
+    expect(props.mouse).toEqual({ x: 3 });
+  });
+
+  test('a throwing props callback is logged and skipped, not fatal', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const hydra = new Hydra({
+      regl: makeStubRegl(),
+      width: 320,
+      height: 240,
+      props: () => {
+        throw new Error('pointer provider not ready');
+      },
+    });
+
+    const sourceDraw = vi.fn();
+    hydra.sources[0].draw = sourceDraw;
+
+    expect(() => hydra.tick(16)).not.toThrow();
+    expect(sourceDraw).toHaveBeenCalledTimes(1);
+    expect(sourceDraw.mock.calls[0][0]).toBe(hydra.synth);
+    expect(log).toHaveBeenCalled();
+    log.mockRestore();
+  });
 });

--- a/test/equivalence/props.test.ts
+++ b/test/equivalence/props.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The `props` option merges user-supplied values into the per-frame props
+ * that sources, outputs, and dynamic uniforms receive — hydra-ts's
+ * dependency-injected equivalent of hydra-synth passing `mouse` to every
+ * draw.
+ */
+import { describe, expect, test, vi } from 'vitest';
+
+import { Hydra } from '../../src/Hydra';
+
+function makeStubRegl() {
+  const stub: any = () => () => {};
+  stub.buffer = (data: unknown) => ({ kind: 'buffer', data });
+  stub.texture = (opts: unknown) => ({ kind: 'texture', opts });
+  stub.framebuffer = (opts: unknown) => ({
+    kind: 'framebuffer',
+    opts,
+    resize: () => {},
+  });
+  stub.prop = (name: string) => `prop:${name}`;
+  return stub;
+}
+
+describe('Hydra props option', () => {
+  test('draws receive synth values merged with user props', () => {
+    const mouse = { x: 42, y: 7 };
+    const hydra = new Hydra({
+      regl: makeStubRegl(),
+      width: 320,
+      height: 240,
+      props: () => ({ mouse }),
+    });
+
+    const sourceDraw = vi.fn();
+    const outputDraw = vi.fn();
+    hydra.sources[0].draw = sourceDraw;
+    hydra.outputs[0].draw = outputDraw as any;
+
+    hydra.tick(16);
+
+    for (const draw of [sourceDraw, outputDraw]) {
+      expect(draw).toHaveBeenCalledTimes(1);
+      const props = draw.mock.calls[0][0];
+      expect(props.mouse).toBe(mouse);
+      expect(props.time).toBe(hydra.synth.time);
+      expect(props.bpm).toBe(hydra.synth.bpm);
+      expect(props.resolution).toEqual([320, 240]);
+    }
+  });
+
+  test('props callback runs once per rendered frame', () => {
+    const props = vi.fn(() => ({ frameValue: 1 }));
+    const hydra = new Hydra({
+      regl: makeStubRegl(),
+      width: 320,
+      height: 240,
+      props,
+    });
+
+    hydra.tick(16);
+    hydra.tick(16);
+
+    expect(props).toHaveBeenCalledTimes(2);
+  });
+
+  test('without the option, draws receive the synth object itself', () => {
+    const hydra = new Hydra({ regl: makeStubRegl(), width: 320, height: 240 });
+
+    const sourceDraw = vi.fn();
+    hydra.sources[0].draw = sourceDraw;
+
+    hydra.tick(16);
+
+    expect(sourceDraw.mock.calls[0][0]).toBe(hydra.synth);
+  });
+});


### PR DESCRIPTION
Dynamic (function) arguments receive `{ time, bpm, resolution, ... }` each frame. hydra-synth additionally passes a global `mouse` object to every draw; hydra-ts deliberately doesn't own inputs like that.

This adds the dependency-injected equivalent: a `props` constructor option whose result is merged into the per-frame draw props.

```ts
const hydra = new Hydra({
  // ...
  props: () => ({ mouse: { x: pointerX, y: pointerY } }),
});

osc(({ mouse }) => mouse.x / 100).out(o0);
```

Upstream-style prop-destructuring sketches become portable with caller-supplied values and no ambient state. The callback runs once per rendered frame; without the option, draws receive the synth object itself (no per-frame allocation).

Tests cover the merge (user values + time/bpm/resolution), per-frame invocation, and the no-option identity path.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_