### PR TITLE
Add createMouse, a dependency-injected port of hydra-synth's mouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,26 @@ Also note that since hydra-synth 1.4.0, arguments for `vec4` inputs must be
 a source or texture; vector literals like `sum([1, 1, 1, 1])` throw, in
 hydra-synth and hydra-ts alike.
 
+#### Mouse input
+
+hydra-synth installs a global `mouse` listener on `window` at import time.
+hydra-ts ships the same tracker as an explicit factory instead — nothing is
+attached until you ask for it:
+
+```ts
+import { createMouse } from 'hydra-ts';
+
+const mouse = createMouse(); // listens on window, like hydra-synth
+// const mouse = createMouse(canvas); // or scope it to an element
+
+osc(() => mouse.x / 100).out(o0);
+
+mouse.enabled = false; // detach listeners when done
+```
+
+`mouse` exposes the same properties as upstream's: `x`, `y`, `buttons`,
+`mods`, and `enabled`.
+
 #### Recreating bidirectional global changes (e.g. assigning `bpm`/`speed` globals)
 
 In the hydra editor, `speed`, `bpm`, and `fps` are assignable globals. In

--- a/index.ts
+++ b/index.ts
@@ -11,3 +11,5 @@ export {
   createTransformChainClass,
 } from './src/glsl/createGenerators.js';
 export { detectPrecision } from './src/lib/detectPrecision.js';
+export { createMouse } from './src/lib/Mouse.js';
+export type { Mouse, MouseMods } from './src/lib/Mouse.js';

--- a/src/lib/Mouse.ts
+++ b/src/lib/Mouse.ts
@@ -1,0 +1,287 @@
+// Port of hydra-synth's lib/mouse.js + lib/mouse-event.js (in turn based on
+// mikolalysenko/mouse-change and mouse-event), with one deliberate
+// difference: hydra-synth attaches a module-level listener to `window` as a
+// global `mouse` object. hydra-ts never attaches anything implicitly — call
+// createMouse() yourself and close over the result, e.g.
+//
+//   const mouse = createMouse();
+//   osc(() => mouse.x / 100).out(o0);
+//
+// Listeners can be detached with `mouse.enabled = false`.
+
+export interface MouseMods {
+  shift: boolean;
+  alt: boolean;
+  control: boolean;
+  meta: boolean;
+}
+
+export type MouseCallback = (
+  buttons: number,
+  x: number,
+  y: number,
+  mods: MouseMods,
+) => void;
+
+interface MouseEventLike {
+  buttons?: number;
+  which?: number;
+  button?: number;
+  pageX?: number;
+  pageY?: number;
+  altKey?: boolean;
+  shiftKey?: boolean;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+}
+
+export interface MouseEventTarget {
+  addEventListener(type: string, listener: (ev: any) => void): void;
+  removeEventListener(type: string, listener: (ev: any) => void): void;
+}
+
+export interface Mouse {
+  readonly element: MouseEventTarget;
+  enabled: boolean;
+  readonly buttons: number;
+  readonly x: number;
+  readonly y: number;
+  readonly mods: MouseMods;
+}
+
+function eventButtons(ev: MouseEventLike): number {
+  if (typeof ev === 'object') {
+    if ('buttons' in ev && ev.buttons !== undefined) {
+      return ev.buttons;
+    } else if ('which' in ev && ev.which !== undefined) {
+      const b = ev.which;
+      if (b === 2) {
+        return 4;
+      } else if (b === 3) {
+        return 2;
+      } else if (b > 0) {
+        return 1 << (b - 1);
+      }
+    } else if ('button' in ev && ev.button !== undefined) {
+      const b = ev.button;
+      if (b === 1) {
+        return 4;
+      } else if (b === 2) {
+        return 2;
+      } else if (b >= 0) {
+        return 1 << b;
+      }
+    }
+  }
+  return 0;
+}
+
+function eventX(ev: MouseEventLike): number {
+  if (typeof ev === 'object' && 'pageX' in ev && ev.pageX !== undefined) {
+    return ev.pageX;
+  }
+  return 0;
+}
+
+function eventY(ev: MouseEventLike): number {
+  if (typeof ev === 'object' && 'pageY' in ev && ev.pageY !== undefined) {
+    return ev.pageY;
+  }
+  return 0;
+}
+
+export function createMouse(
+  element?: MouseEventTarget,
+  callback?: MouseCallback,
+): Mouse {
+  const target: MouseEventTarget =
+    element ?? (window as unknown as MouseEventTarget);
+  // upstream also listens on window for blur/key events when given another
+  // element; do the same where a window exists
+  const globalTarget: MouseEventTarget | undefined =
+    typeof window !== 'undefined' && target !== (window as unknown)
+      ? (window as unknown as MouseEventTarget)
+      : undefined;
+
+  let buttonState = 0;
+  let x = 0;
+  let y = 0;
+  const mods: MouseMods = {
+    shift: false,
+    alt: false,
+    control: false,
+    meta: false,
+  };
+  let attached = false;
+
+  function updateMods(ev: MouseEventLike): boolean {
+    let changed = false;
+    if ('altKey' in ev) {
+      changed = changed || ev.altKey !== mods.alt;
+      mods.alt = !!ev.altKey;
+    }
+    if ('shiftKey' in ev) {
+      changed = changed || ev.shiftKey !== mods.shift;
+      mods.shift = !!ev.shiftKey;
+    }
+    if ('ctrlKey' in ev) {
+      changed = changed || ev.ctrlKey !== mods.control;
+      mods.control = !!ev.ctrlKey;
+    }
+    if ('metaKey' in ev) {
+      changed = changed || ev.metaKey !== mods.meta;
+      mods.meta = !!ev.metaKey;
+    }
+    return changed;
+  }
+
+  function handleEvent(nextButtons: number, ev: MouseEventLike) {
+    const nextX = eventX(ev);
+    const nextY = eventY(ev);
+    if ('buttons' in ev && ev.buttons !== undefined) {
+      nextButtons = ev.buttons | 0;
+    }
+    if (
+      nextButtons !== buttonState ||
+      nextX !== x ||
+      nextY !== y ||
+      updateMods(ev)
+    ) {
+      buttonState = nextButtons | 0;
+      x = nextX || 0;
+      y = nextY || 0;
+      callback && callback(buttonState, x, y, mods);
+    }
+  }
+
+  function clearState(ev: MouseEventLike) {
+    handleEvent(0, ev);
+  }
+
+  function handleBlur() {
+    if (
+      buttonState ||
+      x ||
+      y ||
+      mods.shift ||
+      mods.alt ||
+      mods.meta ||
+      mods.control
+    ) {
+      x = y = 0;
+      buttonState = 0;
+      mods.shift = mods.alt = mods.control = mods.meta = false;
+      callback && callback(0, 0, 0, mods);
+    }
+  }
+
+  function handleMods(ev: MouseEventLike) {
+    if (updateMods(ev)) {
+      callback && callback(buttonState, x, y, mods);
+    }
+  }
+
+  function handleMouseMove(ev: MouseEventLike) {
+    if (eventButtons(ev) === 0) {
+      handleEvent(0, ev);
+    } else {
+      handleEvent(buttonState, ev);
+    }
+  }
+
+  function handleMouseDown(ev: MouseEventLike) {
+    handleEvent(buttonState | eventButtons(ev), ev);
+  }
+
+  function handleMouseUp(ev: MouseEventLike) {
+    handleEvent(buttonState & ~eventButtons(ev), ev);
+  }
+
+  function attachListeners() {
+    if (attached) {
+      return;
+    }
+    attached = true;
+
+    target.addEventListener('mousemove', handleMouseMove);
+    target.addEventListener('mousedown', handleMouseDown);
+    target.addEventListener('mouseup', handleMouseUp);
+
+    target.addEventListener('mouseleave', clearState);
+    target.addEventListener('mouseenter', clearState);
+    target.addEventListener('mouseout', clearState);
+    target.addEventListener('mouseover', clearState);
+
+    target.addEventListener('blur', handleBlur);
+
+    target.addEventListener('keyup', handleMods);
+    target.addEventListener('keydown', handleMods);
+    target.addEventListener('keypress', handleMods);
+
+    if (globalTarget) {
+      globalTarget.addEventListener('blur', handleBlur);
+
+      globalTarget.addEventListener('keyup', handleMods);
+      globalTarget.addEventListener('keydown', handleMods);
+      globalTarget.addEventListener('keypress', handleMods);
+    }
+  }
+
+  function detachListeners() {
+    if (!attached) {
+      return;
+    }
+    attached = false;
+
+    target.removeEventListener('mousemove', handleMouseMove);
+    target.removeEventListener('mousedown', handleMouseDown);
+    target.removeEventListener('mouseup', handleMouseUp);
+
+    target.removeEventListener('mouseleave', clearState);
+    target.removeEventListener('mouseenter', clearState);
+    target.removeEventListener('mouseout', clearState);
+    target.removeEventListener('mouseover', clearState);
+
+    target.removeEventListener('blur', handleBlur);
+
+    target.removeEventListener('keyup', handleMods);
+    target.removeEventListener('keydown', handleMods);
+    target.removeEventListener('keypress', handleMods);
+
+    if (globalTarget) {
+      globalTarget.removeEventListener('blur', handleBlur);
+
+      globalTarget.removeEventListener('keyup', handleMods);
+      globalTarget.removeEventListener('keydown', handleMods);
+      globalTarget.removeEventListener('keypress', handleMods);
+    }
+  }
+
+  attachListeners();
+
+  return {
+    element: target,
+    get enabled() {
+      return attached;
+    },
+    set enabled(f: boolean) {
+      if (f) {
+        attachListeners();
+      } else {
+        detachListeners();
+      }
+    },
+    get buttons() {
+      return buttonState;
+    },
+    get x() {
+      return x;
+    },
+    get y() {
+      return y;
+    },
+    get mods() {
+      return mods;
+    },
+  };
+}

--- a/src/lib/Mouse.ts
+++ b/src/lib/Mouse.ts
@@ -90,10 +90,22 @@ function eventY(ev: MouseEventLike): number {
   return 0;
 }
 
+export function createMouse(callback?: MouseCallback): Mouse;
 export function createMouse(
   element?: MouseEventTarget,
   callback?: MouseCallback,
+): Mouse;
+export function createMouse(
+  element?: MouseEventTarget | MouseCallback,
+  callback?: MouseCallback,
 ): Mouse {
+  // single-function-argument form: createMouse(callback) listens on window,
+  // like upstream's mouseListen(callback)
+  if (typeof element === 'function') {
+    callback = element;
+    element = undefined;
+  }
+
   const target: MouseEventTarget =
     element ?? (window as unknown as MouseEventTarget);
   // upstream also listens on window for blur/key events when given another

--- a/test/equivalence/mouse.test.ts
+++ b/test/equivalence/mouse.test.ts
@@ -1,0 +1,178 @@
+/**
+ * createMouse equivalence: the same event sequences produce the same
+ * x/y/buttons/mods state as hydra-synth's mouse tracker. hydra-synth
+ * attaches its tracker to window at import time; hydra-ts requires explicit
+ * instantiation but tracks identically.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// @ts-ignore - untyped upstream javascript
+import upstreamMouseListen from '../../node_modules/hydra-synth/src/lib/mouse.js';
+
+import { createMouse, Mouse } from '../../src/lib/Mouse';
+
+type Listener = (ev: unknown) => void;
+
+function makeFakeElement() {
+  const listeners = new Map<string, Set<Listener>>();
+  return {
+    addEventListener(type: string, listener: Listener) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(listener);
+    },
+    removeEventListener(type: string, listener: Listener) {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatch(type: string, ev: Record<string, unknown>) {
+      listeners.get(type)?.forEach((listener) => listener(ev));
+    },
+    listenerCount() {
+      let n = 0;
+      listeners.forEach((set) => (n += set.size));
+      return n;
+    },
+  };
+}
+
+// upstream attaches extra listeners to `window` when given another element
+beforeEach(() => {
+  vi.stubGlobal('window', makeFakeElement());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const EVENT_SEQUENCES: Array<{
+  name: string;
+  events: Array<[string, Record<string, unknown>]>;
+}> = [
+  {
+    name: 'mouse movement',
+    events: [
+      ['mousemove', { pageX: 10, pageY: 20, buttons: 0 }],
+      ['mousemove', { pageX: 300, pageY: 5, buttons: 0 }],
+    ],
+  },
+  {
+    name: 'button press and drag',
+    events: [
+      ['mousedown', { pageX: 10, pageY: 20, button: 0, buttons: 1 }],
+      ['mousemove', { pageX: 50, pageY: 60, buttons: 1 }],
+      ['mouseup', { pageX: 50, pageY: 60, button: 0, buttons: 0 }],
+    ],
+  },
+  {
+    name: 'modifier keys',
+    events: [
+      [
+        'keydown',
+        { shiftKey: true, altKey: false, ctrlKey: false, metaKey: false },
+      ],
+      ['mousemove', { pageX: 7, pageY: 8, buttons: 0, shiftKey: true }],
+      [
+        'keyup',
+        { shiftKey: false, altKey: true, ctrlKey: false, metaKey: false },
+      ],
+    ],
+  },
+  {
+    name: 'leave clears button state',
+    events: [
+      ['mousedown', { pageX: 10, pageY: 20, button: 0, buttons: 1 }],
+      ['mouseleave', { pageX: 0, pageY: 0, buttons: 0 }],
+    ],
+  },
+  {
+    name: 'blur resets everything',
+    events: [
+      ['mousemove', { pageX: 99, pageY: 99, buttons: 0 }],
+      ['blur', {}],
+    ],
+  },
+];
+
+function snapshot(mouse: {
+  x: number;
+  y: number;
+  buttons: number;
+  mods: object;
+}) {
+  return {
+    x: mouse.x,
+    y: mouse.y,
+    buttons: mouse.buttons,
+    mods: { ...mouse.mods },
+  };
+}
+
+describe('createMouse', () => {
+  for (const sequence of EVENT_SEQUENCES) {
+    test(`tracks '${sequence.name}' identically to upstream`, () => {
+      const upstreamElement = makeFakeElement();
+      const tsElement = makeFakeElement();
+
+      // upstream treats a single argument as the callback and falls back to
+      // listening on window; pass a noop callback to target the element
+      const upstream = upstreamMouseListen(upstreamElement, () => {});
+      const ours = createMouse(tsElement);
+
+      for (const [type, ev] of sequence.events) {
+        upstreamElement.dispatch(type, ev);
+        tsElement.dispatch(type, ev);
+        expect(snapshot(ours), `after ${type}`).toEqual(snapshot(upstream));
+      }
+    });
+  }
+
+  test('enabled=false detaches all listeners; enabled=true reattaches', () => {
+    const element = makeFakeElement();
+    const mouse = createMouse(element);
+
+    expect(mouse.enabled).toBe(true);
+    expect(element.listenerCount()).toBeGreaterThan(0);
+
+    mouse.enabled = false;
+    expect(element.listenerCount()).toBe(0);
+
+    element.dispatch('mousemove', { pageX: 5, pageY: 5, buttons: 0 });
+    expect(mouse.x).toBe(0);
+
+    mouse.enabled = true;
+    element.dispatch('mousemove', { pageX: 5, pageY: 6, buttons: 0 });
+    expect(mouse.x).toBe(5);
+    expect(mouse.y).toBe(6);
+  });
+
+  test('invokes the optional callback like upstream', () => {
+    const upstreamElement = makeFakeElement();
+    const tsElement = makeFakeElement();
+    const upstreamCalls: unknown[][] = [];
+    const tsCalls: unknown[][] = [];
+
+    upstreamMouseListen(upstreamElement, (...args: unknown[]) =>
+      upstreamCalls.push(structuredClone(args)),
+    );
+    createMouse(tsElement, (...args) => tsCalls.push(structuredClone(args)));
+
+    for (const element of [upstreamElement, tsElement]) {
+      element.dispatch('mousemove', { pageX: 1, pageY: 2, buttons: 0 });
+      element.dispatch('mousedown', {
+        pageX: 1,
+        pageY: 2,
+        button: 0,
+        buttons: 1,
+      });
+    }
+
+    expect(tsCalls).toEqual(upstreamCalls);
+  });
+
+  test('works without a window global when given an element', () => {
+    vi.unstubAllGlobals();
+    const element = makeFakeElement();
+    const mouse: Mouse = createMouse(element);
+    element.dispatch('mousemove', { pageX: 11, pageY: 12, buttons: 0 });
+    expect([mouse.x, mouse.y]).toEqual([11, 12]);
+  });
+});

--- a/test/equivalence/mouse.test.ts
+++ b/test/equivalence/mouse.test.ts
@@ -175,4 +175,17 @@ describe('createMouse', () => {
     element.dispatch('mousemove', { pageX: 11, pageY: 12, buttons: 0 });
     expect([mouse.x, mouse.y]).toEqual([11, 12]);
   });
+
+  test('callback-only form listens on window, like upstream', () => {
+    const fakeWindow = makeFakeElement();
+    vi.stubGlobal('window', fakeWindow);
+
+    const calls: unknown[][] = [];
+    const mouse = createMouse((...args) => calls.push(structuredClone(args)));
+
+    expect(mouse.element).toBe(fakeWindow);
+    fakeWindow.dispatch('mousemove', { pageX: 4, pageY: 9, buttons: 0 });
+    expect([mouse.x, mouse.y]).toEqual([4, 9]);
+    expect(calls).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
A large share of published hydra sketches read `mouse.x`/`mouse.y`. hydra-synth provides this via a tracker attached to `window` at import time — exactly the kind of ambient global this fork avoids.

This ports the same tracker (`lib/mouse.js` + `lib/mouse-event.js`, based on mikolalysenko/mouse-change) as an explicit factory:

```ts
import { createMouse } from 'hydra-ts';

const mouse = createMouse(); // listens on window, like hydra-synth
// const mouse = createMouse(canvas); // or scope it to an element

osc(() => mouse.x / 100).out(o0);

mouse.enabled = false; // detach listeners when done
```

- Nothing attaches until `createMouse()` is called; the target element is injectable; `enabled = false` detaches everything (including the supplementary window listeners upstream also installs when given a non-window element, guarded for environments without `window`).
- The result exposes the same surface as upstream's tracker: `x`, `y`, `buttons`, `mods`, `enabled`, `element`, plus the optional change callback.
- Equivalence tests drive identical event sequences (movement, drag, modifier keys, leave, blur) into upstream's `mouseListen` and `createMouse` and assert identical state and callback invocations.

Pairs naturally with the `props` option from #26 for sketches written as `osc(({ mouse }) => ...)`.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_