### PR TITLE
Make the npm package resolvable by plain Node ESM and slim the tarball

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,13 @@
-export { Hydra } from './src/Hydra';
-export { Source } from './src/Source';
-export { Output } from './src/Output';
-export * as generators from './src/glsl';
+export { Hydra } from './src/Hydra.js';
+export { Source } from './src/Source.js';
+export { Output } from './src/Output.js';
+export * as generators from './src/glsl/index.js';
 export {
   generatorTransforms as defaultGenerators,
   modifierTransforms as defaultModifiers,
-} from './src/glsl/transformDefinitions';
+} from './src/glsl/transformDefinitions.js';
 export {
   createGenerators,
   createTransformChainClass,
-} from './src/glsl/createGenerators';
-export { detectPrecision } from './src/lib/detectPrecision';
+} from './src/glsl/createGenerators.js';
+export { detectPrecision } from './src/lib/detectPrecision.js';

--- a/package.json
+++ b/package.json
@@ -1,17 +1,30 @@
 {
   "name": "hydra-ts",
-  "license": "AGPL",
+  "license": "AGPL-3.0-or-later",
   "version": "1.0.0",
   "description": "A fork of ojack/hydra-synth in typescript, focusing on interoperability.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "src",
+    "index.ts"
+  ],
+  "sideEffects": false,
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
     "dev": "vite",
     "coverage": "vitest run --coverage",
-    "prepack": "tsc || true"
+    "prepack": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -6,10 +6,10 @@ import {
   Regl,
   Resource,
 } from 'regl';
-import { Output } from './Output';
-import { Loop } from './Loop';
-import { Source } from './Source';
-import { solid } from './glsl';
+import { Output } from './Output.js';
+import { Loop } from './Loop.js';
+import { Source } from './Source.js';
+import { solid } from './glsl/index.js';
 
 export type Precision = 'lowp' | 'mediump' | 'highp';
 

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -1,7 +1,7 @@
 import { Attributes, DrawCommand, Framebuffer2D } from 'regl';
-import { GlEnvironment } from './Hydra';
-import { TransformApplication } from './glsl/Glsl';
-import { compileWithEnvironment } from './compiler/compileWithEnvironment';
+import { GlEnvironment } from './Hydra.js';
+import { TransformApplication } from './glsl/Glsl.js';
+import { compileWithEnvironment } from './compiler/compileWithEnvironment.js';
 
 export class Output {
   attributes: Attributes;

--- a/src/Source.ts
+++ b/src/Source.ts
@@ -1,7 +1,7 @@
-import { Webcam } from './lib/Webcam';
-import { Screen } from './lib/Screen';
+import { Webcam } from './lib/Webcam.js';
+import { Screen } from './lib/Screen.js';
 import { Texture2D, TextureImageData } from 'regl';
-import { GlEnvironment, Synth } from './Hydra';
+import { GlEnvironment, Synth } from './Hydra.js';
 
 export class Source {
   environment: GlEnvironment;

--- a/src/compiler/compileWithEnvironment.ts
+++ b/src/compiler/compileWithEnvironment.ts
@@ -1,9 +1,9 @@
-import { GlEnvironment } from '../Hydra';
-import { TypedArg } from './formatArguments';
-import { utilityFunctions } from '../glsl/utilityFunctions';
-import { TransformApplication } from '../glsl/Glsl';
+import { GlEnvironment } from '../Hydra.js';
+import { TypedArg } from './formatArguments.js';
+import { utilityFunctions } from '../glsl/utilityFunctions.js';
+import { TransformApplication } from '../glsl/Glsl.js';
 import { DynamicVariable, DynamicVariableFn, Texture2D, Uniform } from 'regl';
-import { generateGlsl } from './generateGlsl';
+import { generateGlsl } from './generateGlsl.js';
 
 export type CompiledTransform = {
   frag: string;

--- a/src/compiler/formatArguments.ts
+++ b/src/compiler/formatArguments.ts
@@ -1,7 +1,7 @@
-import { Glsl, TransformApplication } from '../glsl/Glsl';
-import arrayUtils from '../lib/array-utils';
-import { TransformDefinitionInput } from '../glsl/transformDefinitions';
-import { src } from '../glsl/index';
+import { Glsl, TransformApplication } from '../glsl/Glsl.js';
+import arrayUtils from '../lib/array-utils.js';
+import { TransformDefinitionInput } from '../glsl/transformDefinitions.js';
+import { src } from '../glsl/index.js';
 
 export interface TypedArg {
   value: unknown;

--- a/src/compiler/generateGlsl.ts
+++ b/src/compiler/generateGlsl.ts
@@ -1,6 +1,6 @@
-import { Glsl, TransformApplication } from '../glsl/Glsl';
-import { formatArguments, TypedArg } from './formatArguments';
-import { ShaderParams } from './compileWithEnvironment';
+import { Glsl, TransformApplication } from '../glsl/Glsl.js';
+import { formatArguments, TypedArg } from './formatArguments.js';
+import { ShaderParams } from './compileWithEnvironment.js';
 
 // This is a port of hydra-synth's src/generate-glsl.js. The emitted shader
 // code (including whitespace) is kept byte-identical to upstream so that

--- a/src/glsl/Glsl.ts
+++ b/src/glsl/Glsl.ts
@@ -1,6 +1,6 @@
-import { Output } from '../Output';
-import ImmutableList from './ImmutableList';
-import { ProcessedTransformDefinition } from './transformDefinitions';
+import { Output } from '../Output.js';
+import ImmutableList from './ImmutableList.js';
+import { ProcessedTransformDefinition } from './transformDefinitions.js';
 
 export interface TransformApplication {
   transform: ProcessedTransformDefinition;

--- a/src/glsl/createGenerators.ts
+++ b/src/glsl/createGenerators.ts
@@ -4,7 +4,7 @@ import {
   TransformDefinitionInput,
   TransformDefinitionType,
 } from './transformDefinitions.js';
-import { Glsl } from './Glsl';
+import { Glsl } from './Glsl.js';
 import ImmutableList from './ImmutableList.js';
 
 type Generator = (...args: unknown[]) => Glsl;

--- a/src/glsl/index.ts
+++ b/src/glsl/index.ts
@@ -1,11 +1,11 @@
 import {
   createGenerators,
   createTransformChainClass,
-} from './createGenerators';
+} from './createGenerators.js';
 import {
   generatorTransforms,
   modifierTransforms,
-} from './transformDefinitions';
+} from './transformDefinitions.js';
 
 const TransformChainClass = createTransformChainClass(modifierTransforms);
 const generators = createGenerators(generatorTransforms, TransformChainClass);

--- a/src/lib/array-utils.ts
+++ b/src/lib/array-utils.ts
@@ -2,7 +2,7 @@
 // Possibly should be integrated with lfo extension, etc.
 // to do: transform time rather than array values, similar to working with coordinates in hydra
 
-import easing from './easing-functions';
+import easing from './easing-functions.js';
 
 const map = (
   num: number,

--- a/src/lib/detectPrecision.ts
+++ b/src/lib/detectPrecision.ts
@@ -1,4 +1,4 @@
-import { Precision } from '../Hydra';
+import { Precision } from '../Hydra.js';
 
 type NavigatorLike = Pick<Navigator, 'platform' | 'maxTouchPoints'>;
 


### PR DESCRIPTION
Packaging/consumption parity with hydra-synth (minus the CJS build — hydra-ts stays ESM-only):

- **`exports` map** (`types` + `import`) alongside `main`/`types`, plus `./package.json`.
- **Plain-Node ESM resolvability**: all relative imports now carry `.js` extensions, so the compiled `dist/` resolves under Node's ESM rules. Previously `import 'hydra-ts'` in plain Node failed with `ERR_MODULE_NOT_FOUND` (`dist/index.js` → `./src/Hydra` extensionless) — the package only worked through bundlers. Verified by installing the packed tarball into a scratch project and building a chain in plain `node`.
- **`files: ["dist", "src", "index.ts"]`** — the tarball previously shipped `dev/`, `test/`, `scripts/`, and the lint configs. `src` stays included, mirroring hydra-synth shipping its source.
- **`sideEffects: false`** for bundler tree-shaking (nothing mutates globals at import time; `ArrayUtils.init()` only does so when called).
- **SPDX license id** `AGPL-3.0-or-later` (was the non-SPDX string `AGPL`).
- **`prepack` now fails on type errors** (`tsc`, previously `tsc || true`).

`version` stays at 1.0.0 — it matches the latest publish on npm, so release bumps remain yours.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_