### PR TITLE
Add detectPrecision, hydra-synth's iOS precision heuristic as a helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ dimensions to avoid sampling/pixelation of high-resolution sketches until finall
 
 You can optionally provide a non-negative number for numOutputs and numSources, as well as a Precision value.
 
+The precision default is `'mediump'`. hydra-synth instead auto-detects iOS
+and uses `'highp'` there (mediump fragment shaders are visibly
+low-precision on iOS); hydra-ts never sniffs the environment implicitly,
+but ships the same heuristic as an opt-in helper:
+
+```ts
+import { Hydra, detectPrecision } from 'hydra-ts';
+
+const hydra = new Hydra({ regl, width, height, precision: detectPrecision() });
+```
+
 #### Recreating the hydra-editor global environment
 
 ```ts

--- a/index.ts
+++ b/index.ts
@@ -10,3 +10,4 @@ export {
   createGenerators,
   createTransformChainClass,
 } from './src/glsl/createGenerators';
+export { detectPrecision } from './src/lib/detectPrecision';

--- a/src/lib/detectPrecision.ts
+++ b/src/lib/detectPrecision.ts
@@ -1,0 +1,34 @@
+import { Precision } from '../Hydra';
+
+type NavigatorLike = Pick<Navigator, 'platform' | 'maxTouchPoints'>;
+
+/**
+ * Replicates hydra-synth's default precision heuristic: 'highp' on iOS
+ * devices (where mediump fragment shaders are visibly low-precision),
+ * 'mediump' everywhere else.
+ *
+ * hydra-synth applies this automatically in its constructor; hydra-ts never
+ * sniffs the environment implicitly, so opt in by passing the result:
+ *
+ *   new Hydra({ precision: detectPrecision(), ... })
+ */
+export function detectPrecision(nav?: NavigatorLike): Precision {
+  const navigatorLike =
+    nav ?? (typeof navigator !== 'undefined' ? navigator : undefined);
+
+  if (navigatorLike === undefined) {
+    return 'mediump';
+  }
+
+  const isIOS =
+    (/iPad|iPhone|iPod/.test(navigatorLike.platform) ||
+      // iPadOS reports MacIntel; the touch screen gives it away
+      (navigatorLike.platform === 'MacIntel' &&
+        navigatorLike.maxTouchPoints > 1)) &&
+    !(
+      typeof window !== 'undefined' &&
+      (window as unknown as { MSStream?: unknown }).MSStream
+    );
+
+  return isIOS ? 'highp' : 'mediump';
+}

--- a/test/equivalence/detectPrecision.test.ts
+++ b/test/equivalence/detectPrecision.test.ts
@@ -1,0 +1,61 @@
+/**
+ * detectPrecision replicates hydra-synth's default precision heuristic
+ * (highp on iOS, mediump elsewhere) as an opt-in, injectable helper.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { detectPrecision } from '../../src/lib/detectPrecision';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('detectPrecision', () => {
+  test.each([
+    ['iPhone', 0, 'highp'],
+    ['iPad', 0, 'highp'],
+    ['iPod', 0, 'highp'],
+    // iPadOS reports MacIntel with a touch screen
+    ['MacIntel', 5, 'highp'],
+    // actual macs
+    ['MacIntel', 0, 'mediump'],
+    ['Win32', 0, 'mediump'],
+    ['Linux x86_64', 0, 'mediump'],
+  ] as const)(
+    "platform '%s' with %i touch points -> %s",
+    (platform, maxTouchPoints, expected) => {
+      expect(detectPrecision({ platform, maxTouchPoints })).toBe(expected);
+    },
+  );
+
+  test('window.MSStream opts out of the iOS detection, like upstream', () => {
+    vi.stubGlobal('window', { MSStream: {} });
+    expect(detectPrecision({ platform: 'iPhone', maxTouchPoints: 0 })).toBe(
+      'mediump',
+    );
+  });
+
+  test('defaults to mediump when no navigator exists', () => {
+    expect(detectPrecision()).toBe('mediump');
+  });
+
+  test('mirrors the heuristic hydra-synth applies in its constructor', () => {
+    // alarm if upstream changes its detection logic
+    const upstreamSource = readFileSync(
+      new URL(
+        '../../node_modules/hydra-synth/src/hydra-synth.js',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(upstreamSource).toContain(
+      '/iPad|iPhone|iPod/.test(navigator.platform)',
+    );
+    expect(upstreamSource).toContain(
+      "navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1",
+    );
+    expect(upstreamSource).toContain('!window.MSStream');
+    expect(upstreamSource).toContain("isIOS ? 'highp' : 'mediump'");
+  });
+});


### PR DESCRIPTION
hydra-synth defaults to `highp` on iOS — detected via navigator sniffing in its constructor — because `mediump` fragment shaders are visibly low-precision there. hydra-ts keeps its explicit `'mediump'` default and never sniffs the environment implicitly; this ships the same heuristic as an opt-in, injectable helper:

```ts
import { Hydra, detectPrecision } from 'hydra-ts';

const hydra = new Hydra({ regl, width, height, precision: detectPrecision() });
```

- Accepts an optional navigator-like object (`platform`, `maxTouchPoints`) for testing/DI; falls back to the global `navigator` when present, `'mediump'` otherwise.
- Covers the iPadOS case (`MacIntel` + touch points) and the `window.MSStream` opt-out, matching upstream exactly.
- A test pins the heuristic against hydra-synth's source text, so an upstream change to the detection logic fails loudly here.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_