### PR TITLE
Label sources and outputs ('s0', 'o1', ...), like hydra-synth

### DIFF
--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -202,12 +202,12 @@ export class Hydra {
         : undefined;
 
     for (let i = 0; i < numSources; i++) {
-      const s = new Source(glEnvironment);
+      const s = new Source(glEnvironment, `s${i}`);
       sources.push(s);
     }
 
     for (let i = 0; i < numOutputs; i++) {
-      const o = new Output(glEnvironment);
+      const o = new Output(glEnvironment, `o${i}`);
       outputs.push(o);
     }
 

--- a/src/Output.ts
+++ b/src/Output.ts
@@ -10,9 +10,12 @@ export class Output {
   environment: GlEnvironment;
   vert: string;
   pingPongIndex = 0;
+  // identity for debugging/inspection ('o0', 'o1', ...), like hydra-synth's
+  readonly label: string;
 
-  constructor(environment: GlEnvironment) {
+  constructor(environment: GlEnvironment, label = '') {
     this.environment = environment;
+    this.label = label;
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/Source.ts
+++ b/src/Source.ts
@@ -8,9 +8,12 @@ export class Source {
   src?: TextureImageData;
   dynamic: boolean;
   tex: Texture2D;
+  // identity for debugging/inspection ('s0', 's1', ...), like hydra-synth's
+  readonly label: string;
 
-  constructor(environment: GlEnvironment) {
+  constructor(environment: GlEnvironment, label = '') {
     this.environment = environment;
+    this.label = label;
     this.src = undefined;
     this.dynamic = true;
     this.tex = environment.regl.texture({

--- a/test/equivalence/labels.test.ts
+++ b/test/equivalence/labels.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Sources and outputs carry identity labels ('s0', 'o1', ...) like
+ * hydra-synth's, for debugging and inspection.
+ */
+import { describe, expect, test } from 'vitest';
+
+import { Hydra } from '../../src/Hydra';
+import { Output } from '../../src/Output';
+import { Source } from '../../src/Source';
+import { GlEnvironment } from '../../src/Hydra';
+
+function makeStubRegl() {
+  const stub: any = () => () => {};
+  stub.buffer = (data: unknown) => ({ kind: 'buffer', data });
+  stub.texture = (opts: unknown) => ({ kind: 'texture', opts });
+  stub.framebuffer = (opts: unknown) => ({
+    kind: 'framebuffer',
+    opts,
+    resize: () => {},
+  });
+  stub.prop = (name: string) => `prop:${name}`;
+  return stub;
+}
+
+describe('labels', () => {
+  test('Hydra labels its sources and outputs like hydra-synth', () => {
+    const hydra = new Hydra({ regl: makeStubRegl(), width: 320, height: 240 });
+
+    expect(hydra.sources.map((s) => s.label)).toEqual(['s0', 's1', 's2', 's3']);
+    expect(hydra.outputs.map((o) => o.label)).toEqual(['o0', 'o1', 'o2', 'o3']);
+  });
+
+  test('labels follow numSources/numOutputs', () => {
+    const hydra = new Hydra({
+      regl: makeStubRegl(),
+      width: 320,
+      height: 240,
+      numSources: 2,
+      numOutputs: 6,
+    });
+
+    expect(hydra.sources.map((s) => s.label)).toEqual(['s0', 's1']);
+    expect(hydra.outputs.at(-1)!.label).toBe('o5');
+  });
+
+  test("directly-constructed instances default to '', like upstream", () => {
+    const environment = { regl: makeStubRegl() } as unknown as GlEnvironment;
+    expect(new Source(environment).label).toBe('');
+    expect(new Output(environment).label).toBe('');
+  });
+});


### PR DESCRIPTION
Mirrors the `label` constructor parameter hydra-synth gives `HydraSource` and `Output`: `Hydra` now labels its sources `'s0'…` and outputs `'o0'…`, making instances identifiable when debugging or inspecting (e.g. telling which output a chain rendered to). Directly constructed instances default to `''`, also like upstream.

Pure identity metadata — no behavior change.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_