### PR TITLE
Keep the render loop alive when a frame fails, like hydra-synth

### DIFF
--- a/src/Hydra.ts
+++ b/src/Hydra.ts
@@ -254,52 +254,61 @@ export class Hydra {
 
   // dt in ms
   tick = (dt: number) => {
-    this.synth.time += dt * 0.001 * this.synth.speed;
+    // like hydra-synth, a failing frame is logged rather than thrown, so an
+    // error (e.g. from a dynamic uniform) doesn't break the render loop
+    try {
+      this.synth.time += dt * 0.001 * this.synth.speed;
 
-    this.#timeSinceLastUpdate += dt;
+      this.#timeSinceLastUpdate += dt;
 
-    if (!this.synth.fps || this.#timeSinceLastUpdate >= 1000 / this.synth.fps) {
-      this.synth.stats.fps = Math.ceil(1000 / this.#timeSinceLastUpdate);
+      if (
+        !this.synth.fps ||
+        this.#timeSinceLastUpdate >= 1000 / this.synth.fps
+      ) {
+        this.synth.stats.fps = Math.ceil(1000 / this.#timeSinceLastUpdate);
 
-      if (this.synth.update) {
-        try {
-          this.synth.update(this.#timeSinceLastUpdate);
-        } catch (e) {
-          console.log(e);
+        if (this.synth.update) {
+          try {
+            this.synth.update(this.#timeSinceLastUpdate);
+          } catch (e) {
+            console.log(e);
+          }
         }
-      }
 
-      this.sources.forEach((source) => {
-        source.draw(this.synth);
-      });
-
-      this.outputs.forEach((output) => {
-        output.draw(this.synth);
-      });
-
-      if (this.#isRenderingAll && this.#renderAll) {
-        this.#renderAll({
-          tex0: this.outputs[0].getCurrent(),
-          tex1: this.outputs[1].getCurrent(),
-          tex2: this.outputs[2].getCurrent(),
-          tex3: this.outputs[3].getCurrent(),
+        this.sources.forEach((source) => {
+          source.draw(this.synth);
         });
-      } else {
-        this.#renderFbo({
-          tex0: this.#output.getCurrent(),
-          resolution: this.synth.resolution,
-        });
-      }
 
-      if (this.synth.afterUpdate) {
-        try {
-          this.synth.afterUpdate(this.#timeSinceLastUpdate);
-        } catch (e) {
-          console.log(e);
+        this.outputs.forEach((output) => {
+          output.draw(this.synth);
+        });
+
+        if (this.#isRenderingAll && this.#renderAll) {
+          this.#renderAll({
+            tex0: this.outputs[0].getCurrent(),
+            tex1: this.outputs[1].getCurrent(),
+            tex2: this.outputs[2].getCurrent(),
+            tex3: this.outputs[3].getCurrent(),
+          });
+        } else {
+          this.#renderFbo({
+            tex0: this.#output.getCurrent(),
+            resolution: this.synth.resolution,
+          });
         }
-      }
 
-      this.#timeSinceLastUpdate = 0;
+        if (this.synth.afterUpdate) {
+          try {
+            this.synth.afterUpdate(this.#timeSinceLastUpdate);
+          } catch (e) {
+            console.log(e);
+          }
+        }
+
+        this.#timeSinceLastUpdate = 0;
+      }
+    } catch (e) {
+      console.warn('Error during tick():', e);
     }
   };
 }

--- a/test/equivalence/tickResilience.test.ts
+++ b/test/equivalence/tickResilience.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Like hydra-synth, a failing frame is logged ("Error during tick():") and
+ * does not break the render loop.
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+import { Hydra } from '../../src/Hydra';
+
+function makeStubRegl() {
+  const stub: any = () => () => {};
+  stub.buffer = (data: unknown) => ({ kind: 'buffer', data });
+  stub.texture = (opts: unknown) => ({ kind: 'texture', opts });
+  stub.framebuffer = (opts: unknown) => ({
+    kind: 'framebuffer',
+    opts,
+    resize: () => {},
+  });
+  stub.prop = (name: string) => `prop:${name}`;
+  return stub;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('tick resilience', () => {
+  test('a throwing draw is logged, not thrown, and later frames recover', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const hydra = new Hydra({ regl: makeStubRegl(), width: 320, height: 240 });
+
+    let shouldThrow = true;
+    const draws: number[] = [];
+    hydra.sources[0].draw = () => {
+      if (shouldThrow) {
+        throw new Error('bad frame');
+      }
+      draws.push(hydra.synth.time);
+    };
+
+    expect(() => hydra.tick(16)).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      'Error during tick():',
+      expect.any(Error),
+    );
+
+    // the loop keeps running and recovers once the failure clears
+    shouldThrow = false;
+    hydra.tick(16);
+    expect(draws).toHaveLength(1);
+  });
+
+  test('time keeps advancing across failing frames', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const hydra = new Hydra({ regl: makeStubRegl(), width: 320, height: 240 });
+
+    hydra.outputs[0].draw = (() => {
+      throw new Error('bad frame');
+    }) as any;
+
+    hydra.tick(16);
+    hydra.tick(16);
+
+    expect(hydra.synth.time).toBeCloseTo(0.032, 6);
+  });
+
+  test('matches the warning hydra-synth emits', () => {
+    // alarm if upstream changes its tick error handling
+    const upstreamSource = readFileSync(
+      new URL(
+        '../../node_modules/hydra-synth/src/hydra-synth.js',
+        import.meta.url,
+      ),
+      'utf8',
+    );
+    expect(upstreamSource).toContain("console.warn('Error during tick():', e)");
+  });
+});


### PR DESCRIPTION
hydra-synth wraps its entire `tick()` in try/catch so one bad frame (a throwing dynamic uniform, a draw error) is logged and the render loop keeps going. hydra-ts only guarded the `update`/`afterUpdate` callbacks; anything else propagated out of the raf callback and spammed uncaught errors every frame.

The whole tick body is now guarded, emitting upstream's exact `console.warn('Error during tick():', e)`, and later frames recover. The dedicated `update`/`afterUpdate` guards are unchanged.

Deliberately unaffected: compile-time errors — `.out()` still throws to the caller, as documented in the README's "Differences" section. This PR is only about not letting a transient frame failure kill the loop.

Tests cover: a throwing draw is logged not thrown and the loop recovers when the failure clears; time keeps advancing across failing frames; and a source-text pin on upstream's warning so a change there fails loudly.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_