### PR TITLE
Document synth.speed/bpm/fps assignment; drop stale unsupported note

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,17 @@ hydra-synth and hydra-ts alike.
 
 #### Recreating bidirectional global changes (e.g. assigning `bpm`/`speed` globals)
 
-This is not presently supported.
+In the hydra editor, `speed`, `bpm`, and `fps` are assignable globals. In
+hydra-ts they are plain mutable fields on `hydra.synth`:
+
+```ts
+hydra.synth.speed = 2; // time advances twice as fast
+hydra.synth.bpm = 120; // affects array sequencing ([1, 2].fast(...))
+hydra.synth.fps = 30; // cap the render rate (undefined = uncapped)
+```
+
+Reading them works the same way (`hydra.synth.time`, `hydra.synth.stats.fps`).
+There are no window-level globals to assign; each instance owns its state.
 
 ## Equivalence with upstream
 


### PR DESCRIPTION
The README still said recreating the editor's bidirectional globals (`speed`/`bpm`) was "not presently supported." That's been stale since the hydra-synth 1.4.0 sync: they are plain mutable fields on `hydra.synth`, alongside `fps` and the `update`/`afterUpdate` callbacks.

The section now documents the actual usage:

```ts
hydra.synth.speed = 2; // time advances twice as fast
hydra.synth.bpm = 120; // affects array sequencing ([1, 2].fast(...))
hydra.synth.fps = 30; // cap the render rate (undefined = uncapped)
```

Docs only — no code changes. (The other stale README line — the `.out(o#)` requirement — is updated by #25, which changes the behavior it describes.)

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_