### PR TITLE
Release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ts",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL",
       "dependencies": {
         "regl": "^1.3.9"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hydra-ts",
   "license": "AGPL-3.0-or-later",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A fork of ojack/hydra-synth in typescript, focusing on interoperability.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps `version` to `1.1.0` (and syncs `package-lock.json`) for the first tagged release since the hydra-synth 1.4.0 sync.

A minor bump: everything since 1.0.0 is additive — the 1.4.0 sync keeps shader output byte-identical (enforced by the equivalence suite), and the new public surface is all opt-in.

### What's in 1.1.0

**hydra-synth 1.4.0 sync** (#23) — byte-identical compiled shaders, verified against the pinned hydra-synth devDependency.

**Upstream alignment, fork-style (no globals, dependency-injected):**
- Instance-bound generators with a default output — `hydra.generators.osc().out()` (#25)
- `createMouse()` — the mouse tracker as an explicit factory (#27)
- `props` option for injecting per-frame values like `mouse` (#26)
- `detectPrecision()` — opt-in iOS `highp` heuristic (#30)
- `Glsl.glsl(environment)` — compile a chain without rendering (#28)
- Source texture `params` passthrough (filtering) (#24)
- Source/output labels `s0`/`o1` (#31)
- Tick resilience — a failing frame is logged, not fatal (#32)
- ESM packaging: plain-Node-resolvable `exports`, slimmed tarball (#29)
- Docs: `synth.speed/bpm/fps`, removed stale notes (#33)

After merge I'll tag `v1.1.0` on the merge commit. No npm publish is automated, so the actual `npm publish` stays a manual step.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_