### PR TITLE
Add release workflow: npm publish + tag + GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+# Publishes the package to npm, then tags vX.Y.Z and creates the GitHub
+# Release. Trigger manually (workflow_dispatch) after landing a version bump
+# on main, or by pushing a v* tag.
+#
+# Requires the NPM_TOKEN repository secret (an npm "Automation" token, which
+# bypasses OTP): Settings -> Secrets and variables -> Actions.
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write # push the version tag and create the GitHub Release
+  id-token: write # npm --provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check NPM_TOKEN is configured
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::The NPM_TOKEN repository secret is not configured. Create an npm Automation token and add it under Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag and create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          TAG="v$VERSION"
+          if ! git ls-remote --exit-code --tags origin "$TAG" >/dev/null; then
+            git tag "$TAG" "$GITHUB_SHA"
+            git push origin "$TAG"
+          fi
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            gh release create "$TAG" --title "hydra-ts $VERSION" --generate-notes
+          fi


### PR DESCRIPTION
Publishing hydra-ts@1.1.0 to npm can't happen from the dev environment (no credentials there, and the git proxy blocks tag pushes), so this adds the release path that *can* be driven remotely:

- **`workflow_dispatch`** (or pushing a `v*` tag) runs: `npm ci` → typecheck → full test suite → `npm publish --provenance` → pushes the `vX.Y.Z` tag → creates the GitHub Release with generated notes.
- Uses the **`NPM_TOKEN` repository secret** (an npm *Automation* token, which bypasses OTP). Fails fast with a clear error if the secret isn't configured.
- `--provenance` attaches a supply-chain attestation linking the npm package to this repo/commit.
- Tag and Release steps are idempotent (skipped if they already exist), so re-running after a partial failure is safe.

Once this lands and the `NPM_TOKEN` secret is added (Settings → Secrets and variables → Actions), dispatching the workflow on `main` (currently `d16025d`, version 1.1.0) publishes the release end-to-end.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_