### PR TITLE
tsconfig: moduleResolution Node (node10) → NodeNext

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
   "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "module": "ES2020",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist/"
   }
 }


### PR DESCRIPTION
Switches `moduleResolution` from `Node` (the legacy `node10` algorithm) to `NodeNext`, with `module: NodeNext` to match.

`node10` is deprecated and slated for removal in TypeScript 7 — it's the recurring `Option 'moduleResolution=node10' is deprecated` warning we kept seeing. `NodeNext` is the correct setting for this ESM package (`"type": "module"`, exports map, explicit `.js` import extensions): it resolves through the exports map and *validates* the `.js` extensions instead of silently ignoring them, so a missing/incorrect extension now becomes a tsc error.

Verified: `tsc --noEmit` clean, `dist/` builds, a packed-tarball consumer resolves `hydra-ts` in plain Node ESM, and the 298-test suite is unaffected (this only touches type resolution, not emitted shader output).

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_