### PR TITLE
Automate dependency upkeep and modernize CI/release runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # npm dependencies: weekly, grouped to keep PR noise down.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # routine minor/patch bumps land in a single PR per week
+      dev-minor-and-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # hydra-synth is pinned deliberately: the equivalence suite compiles
+      # against this exact version. Bump it intentionally (re-run
+      # scripts/generate-transform-definitions.mjs), not via dependabot.
+      - dependency-name: hydra-synth
+
+  # GitHub Actions used by the CI and release workflows.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # the minimum supported (engines: node >=22) and the current LTS
+        node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npx tsc --noEmit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,17 +29,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest # trusted publishing requires a cloud-hosted runner
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      # Node 24 bundles npm >= 11.5.1, which trusted publishing requires for
+      # the OIDC exchange (Node 22 ships npm 10.x and would need an upgrade).
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22 # >= 22.14.0; matches the CI test matrix
+          node-version: 24
           cache: npm
           registry-url: https://registry.npmjs.org
-
-      # Trusted publishing requires npm >= 11.5.1, but Node 22 still bundles
-      # npm 10.x — upgrade so `npm publish` performs the OIDC exchange.
-      - run: npm install -g npm@latest
 
       - run: npm ci
       - run: npx tsc --noEmit


### PR DESCRIPTION
Repo automation bundle.

- **`.github/dependabot.yml`** — weekly `npm` + `github-actions` updates. Dev minor/patch bumps are grouped into a single weekly PR to cut noise, and `hydra-synth` is ignored (it's pinned for the equivalence suite and must be bumped intentionally via `scripts/generate-transform-definitions.mjs`, not piecemeal).
- **CI** — now tests on a **Node `[22, 24]` matrix** (the `engines` floor and the current Active LTS), and bumps `actions/checkout` + `actions/setup-node` to **v6**.
- **Release** — runs on **Node 24** (which bundles npm 11.13, satisfying trusted publishing's npm ≥ 11.5.1) and **drops the explicit `npm install -g npm@latest` step**; actions bumped to v6.

Verified locally on the rebased stack: `tsc` clean, 298 tests pass. This PR's own CI exercises the new matrix on the modern vitest-4 deps (Node 24 officially supported), and dependabot will keep deps + action versions current going forward.

Follow-up after this lands: I'll close the stale dependabot PRs (#4–#18) that target transitives no longer in the tree.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_