### PR TITLE
Upgrade to TypeScript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "hydra-synth": "1.4.0",
         "prettier": "^3.8.4",
         "regl": "^2.1.1",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.0",
         "vitest": "^4.1.8"
@@ -3072,9 +3072,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "hydra-synth": "1.4.0",
     "prettier": "^3.8.4",
     "regl": "^2.1.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.8"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,11 @@
     "declaration": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    // The package runs on Node 22+ and modern browsers. Pin lib explicitly
+    // so the available runtime APIs don't depend on the base target (TS 6
+    // no longer pulls in es2017+ globals like Object.values by default).
+    // This is type-only and does not change the emitted output.
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "outDir": "dist/"
   }
 }


### PR DESCRIPTION
Bumps `typescript` ^5.9.3 → **^6.0.3** (within typescript-eslint 8's peer range of `<6.1`).

**The one required change:** TS 6 no longer pulls `es2017+` globals (`Object.values`, etc.) into scope from the base `target` the way TS 5.9 did, which surfaced 5 errors (one `Object.values` not-found, the rest cascading implicit-`any`s). The fix is to make `lib` explicit — `["ES2023", "DOM", "DOM.Iterable"]`, matching the Node 22+ / modern-browser runtime the package already targets (and declares via `engines`). This was previously relying on TS's implicit defaults.

**Emit-preserving:** `lib` is type-only — I built `dist` under both TS 5.9 and TS 6 and **diffed the full output: byte-identical**. No behavior or output change for consumers; the compiled JS and `.d.ts` are unchanged. (Modernizing the *emit* target — e.g. dropping the ES2015 WeakMap downleveling of private fields — is a separate, optional follow-up I kept out of this PR.)

Verified: `tsc --noEmit` clean, `npm run lint` + `format:check` clean (typescript-eslint parses fine under TS 6), **298 tests pass**, plain-Node consumer resolves `hydra-ts`.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_