### PR TITLE
Compile to ES2022 (native private/class fields)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,10 @@
     "declaration": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    // The package targets Node 22+ and modern browsers, so emit native
+    // ES2022 (real #private fields, class fields) rather than downleveling
+    // to WeakMap helpers. Overrides the base target of es2016.
+    "target": "ES2022",
     // The package runs on Node 22+ and modern browsers. Pin lib explicitly
     // so the available runtime APIs don't depend on the base target (TS 6
     // no longer pulls in es2017+ globals like Object.values by default).


### PR DESCRIPTION
Sets `target: ES2022` (overriding the base `es2016`). The package targets Node 22+ and modern browsers (per `engines`), so there's no reason to downlevel — the emitted `dist` now uses **native `#private` fields, native class fields, and object spread** instead of WeakMap helpers, `Object.assign`, and constructor assignments.

**Behavior-preserving — verified three ways:**
- Diffed `dist` against the `es2016` build: the only changes are that modernization (e.g. `Loop.js` `#ts`/`#running` are now native; `Object.assign({...}, {...})` → `{...}` spread). No logic changes.
- `tsc --noEmit` clean under ES2022 (no `useDefineForClassFields` surprises — our classes assign in constructors / use plain field initializers).
- Ran the compiled ES2022 `dist` in **real Node**: constructed `Hydra` with a stub regl and drove `tick()`, which advances `synth.time` through the now-native `#timeSinceLastUpdate`/`#output`/`#renderFbo` fields. (The vitest suite runs against source via esbuild, so this separately validates the actual emitted output.)

Plus the usual gate: 298 tests pass, lint + format clean.

This is the emit-cleanup follow-up I flagged after the TypeScript 6 PR. No API or behavior change for consumers — just smaller, modern output.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_