### PR TITLE
Release 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydra-ts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydra-ts",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hydra-ts",
   "license": "AGPL-3.0-or-later",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A fork of ojack/hydra-synth in typescript, focusing on interoperability.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Patch release. Bumps `version` 1.1.0 → 1.1.1 (and the lockfile).

Ships the toolchain modernization merged since 1.1.0 was published:
- tsconfig `NodeNext` (#37)
- vite 8 / vitest 4, `@types/node` 22, **`regl` → peerDependency**, `engines: node >=22`, `.nvmrc` (#38)
- dependabot + CI Node 22/24 matrix + Node 24 release (#39)
- ESLint 9 flat config + typescript-eslint 8 + Prettier 3, enforced in CI (#41)
- `@tsconfig/recommended` 1.0.13 (#40)
- **TypeScript 6** with explicit `lib` (#42)
- **ES2022 output** — native `#private`/class fields (#43)

No public API change and no behavior change — compiled shader output stays byte-identical to hydra-synth (the equivalence suite gated every PR). The one consumer-visible packaging note: `regl` is now a **peer** dependency (install it alongside `hydra-ts`); in practice you already supplied a regl instance to `new Hydra({ regl })`.

After merge I'll dispatch the **Release** workflow (trusted publishing) to publish `hydra-ts@1.1.1`, tag `v1.1.1`, and create the GitHub release.

https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRBjqJymKPCk8qhYaVoPAX)_